### PR TITLE
Fix bootstrap script name to existing one

### DIFF
--- a/examples/aws.go
+++ b/examples/aws.go
@@ -73,7 +73,7 @@ func getCluster(name string) *cluster.Cluster {
 				MinCount:        1,
 				Image:           "ami-835b4efa",
 				Size:            "t2.medium",
-				BootstrapScript: "1.7.0_ubuntu_16.04_master.sh",
+				BootstrapScript: "amazon_k8s_ubuntu_16.04_master.sh",
 				Subnets: []*cluster.Subnet{
 					{
 						Name:     fmt.Sprintf("%s.master", name),
@@ -109,7 +109,7 @@ func getCluster(name string) *cluster.Cluster {
 				MinCount:        1,
 				Image:           "ami-835b4efa",
 				Size:            "t2.medium",
-				BootstrapScript: "1.7.0_ubuntu_16.04_node.sh",
+				BootstrapScript: "amazon_k8s_ubuntu_16.04_node.sh",
 				Subnets: []*cluster.Subnet{
 					{
 						Name:     fmt.Sprintf("%s.node", name),


### PR DESCRIPTION
AWS bootstrap example is failing due to wrong bootstrap script name.

 This PR fixes bootstrap script name from `1.7.0_ubuntu_16.04_master.sh` to `amazon_k8s_ubuntu_16.04_master.sh` and `1.7.0_ubuntu_16.04_node.sh` to `amazon_k8s_ubuntu_16.04_node.sh` 